### PR TITLE
CL_VERSION_1_2 is not defined on OpenCL 1.1 / 1.0

### DIFF
--- a/src/kernels.cl
+++ b/src/kernels.cl
@@ -1,5 +1,5 @@
 // enable extension for OpenCL 1.1 and lower
-#if __OPENCL_VERSION__ < CL_VERSION_1_2
+#if __OPENCL_VERSION__ < 120
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable
 #endif
 


### PR DESCRIPTION
CL_VERSION_1_2 does not need to be defined on OpenCL 1.1 and lower.

This is a fix for #2, sorry for that.
